### PR TITLE
added CC BY-NC-ND 4.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,40 @@
-MIT License
+# Project Report
+
+All dsci_552_group2 material is
+made available under the **Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International**
+([CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)). 
+
+This is a human-readable summary of (and not a substitute for) the license: 
+
+## You are free to:
+**Share** — copy and redistribute the material in any medium or format
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+## Under the following terms:
+
+**Attribution** — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+**NonCommercial** — You may not use the material for commercial purposes.
+
+**NoDerivative** — If you remix, transform, or build upon the material, you may not distribute the modified material.
+
+**No additional restrictions** — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+## Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+
+# Software
+
+Except where otherwise noted, the example programs and other software
+provided in the dsci_552_group2 repository are made available under the
+MIT license.
+
+
+**MIT License**
 
 Copyright (c) 2022 Master of Data Science at the University of British Columbia
 


### PR DESCRIPTION
Added the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0) license per the [instructions](https://pages.github.ubc.ca/MDS-2022-23/DSCI_522_dsci-workflows_students/materials/assignments/milestone1.html#iv-license-file) and [example](https://github.com/ttimbers/breast_cancer_predictor/blob/master/LICENSE) 